### PR TITLE
Fixed uncaught when bot is mentioned without a message.

### DIFF
--- a/lib/Listeners.js
+++ b/lib/Listeners.js
@@ -112,6 +112,9 @@ var Listeners = function () {
         return entry.type === type;
       });
 
+      // apparently value can still be undefined here if a bot is just mentioned without a message
+      value = value || ''
+
       for (var i = 0; i < entries.length; i++) {
         // get first entry, or first match
         if (!entries[i].matcher || value.match(entries[i].matcher)) {


### PR DESCRIPTION
I added concierge-droid using gynoid, and I was getting an uncaught when just mentioning the bot (i.e. "@concierge") without adding any text messages. It seems in this case, `value` was overwritten with an undefined, thus generating this exception.

Complete trace:
```
[Tue Aug 15 2017 15:01:32 GMT-0300 (ART)] INFO Logged in as concierge
/gynoid/node_modules/slack-robot/lib/Listeners.js:117
        if (!entries[i].matcher || value.match(entries[i].matcher)) {
                                        ^

TypeError: Cannot read property 'match' of undefined
    at Listeners.find (/gynoid/node_modules/slack-robot/lib/Listeners.js:117:41)
    at Robot._onMessage (/gynoid/node_modules/slack-robot/lib/Robot.js:495:38)
    at RTMClient.<anonymous> (/gynoid/node_modules/slack-robot/lib/Robot.js:408:16)
    at RTMClient.emit (/gynoid/node_modules/eventemitter3/index.js:116:35)
    at RTMClient.emit (/gynoid/node_modules/@slack/client/lib/clients/client.js:82:39)
    at RTMClient._handleWsMessageViaEventHandler (/gynoid/node_modules/@slack/client/lib/clients/rtm/client.js:471:10)
    at RTMClient.handleWsMessage (/gynoid/node_modules/@slack/client/lib/clients/rtm/client.js:425:10)
    at WebSocket.wrapper (/gynoid/node_modules/lodash/lodash.js:4968:19)
    at emitTwo (events.js:87:13)
    at WebSocket.emit (events.js:172:7)
    at Receiver.ontext (/gynoid/node_modules/ws/lib/WebSocket.js:841:10)
    at /gynoid/node_modules/ws/lib/Receiver.js:536:18
    at Receiver.applyExtensions (/gynoid/node_modules/ws/lib/Receiver.js:371:5)
    at /gynoid/node_modules/ws/lib/Receiver.js:508:14
    at Receiver.flush (/gynoid/node_modules/ws/lib/Receiver.js:347:3)
    at Receiver.opcodes.1.finish (/gynoid/node_modules/ws/lib/Receiver.js:541:12)
    at Receiver.expectHandler (/gynoid/node_modules/ws/lib/Receiver.js:499:31)
    at Receiver.add (/gynoid/node_modules/ws/lib/Receiver.js:103:24)
    at TLSSocket.realHandler (/gynoid/node_modules/ws/lib/WebSocket.js:825:20)
    at emitOne (events.js:77:13)
    at TLSSocket.emit (events.js:169:7)
    at readableAddChunk (_stream_readable.js:146:16)
```