### PR TITLE
Migrate slack api usage to promises

### DIFF
--- a/lib/Response.js
+++ b/lib/Response.js
@@ -367,32 +367,26 @@ var Response = function (_EventEmitter) {
       if (task.target.indexOf(USER_PREFIX) > -1) {
         var userId = task.target.replace(USER_PREFIX, '');
 
-        return this._api.im.open({ user: userId }, function (err, data) {
-          if (err) {
-            return callback(err);
-          }
-
+        return this._api.im.open({ user: userId }).then(function (data) {
           if (!data.ok) {
             return callback(new Error(data.error));
           }
-
           task.target = data.channel.id;
-          _this6._sendResponse(task, callback);
+          return _this6._sendResponse(task, callback);
+        }).catch(function (err) {
+          return callback(err);
         });
       } else if (task.target.indexOf(MPIM_PREFIX) > -1) {
         var userIds = task.target.replace(MPIM_PREFIX, '');
-
-        return this._api.mpim.open(userIds, function (err, data) {
-          if (err) {
-            return callback(err);
-          }
-
+        return this._api.mpim.open(userIds).then(function (data) {
           if (!data.ok) {
             return callback(new Error(data.error));
           }
 
           task.target = data.group.id;
-          _this6._sendResponse(task, callback);
+          return _this6._sendResponse(task, callback);
+        }).catch(function (err) {
+          return callback(err);
         });
       }
 
@@ -442,12 +436,10 @@ var Response = function (_EventEmitter) {
         text: text,
         channel: id
       });
-      this._api.chat.postMessage(postMessageArguments, function (err, res) {
-        if (err) {
-          return callback(err);
-        }
-
+      this._api.chat.postMessage(postMessageArguments).then(function (res) {
         callback(null, res);
+      }).catch(function (err) {
+        return callback(err);
       });
     }
 
@@ -470,12 +462,10 @@ var Response = function (_EventEmitter) {
         channel: id
       });
 
-      this._api.chat.postMessage(opts, function (err, res) {
-        if (err) {
-          return callback(err);
-        }
-
+      this._api.chat.postMessage(opts).then(function (res) {
         callback(null, res);
+      }).catch(function (err) {
+        return callback(err);
       });
     }
 

--- a/src/Response.js
+++ b/src/Response.js
@@ -278,33 +278,31 @@ export default class Response extends EventEmitter {
     if (task.target.indexOf(USER_PREFIX) > -1) {
       const userId = task.target.replace(USER_PREFIX, '');
 
-      return this._api.im.open({user: userId}, (err, data) => {
-        if (err) {
+      return this._api.im.open({user: userId})
+        .then((data) => {
+          if (!data.ok) {
+            return callback(new Error(data.error));
+          }
+          task.target = data.channel.id;
+          return this._sendResponse(task, callback);  
+        })
+        .catch((err) => {
           return callback(err);
-        }
-
-        if (!data.ok) {
-          return callback(new Error(data.error));
-        }
-
-        task.target = data.channel.id;
-        this._sendResponse(task, callback);
-      });
+        });
     } else if (task.target.indexOf(MPIM_PREFIX) > -1) {
       const userIds = task.target.replace(MPIM_PREFIX, '');
-
-      return this._api.mpim.open(userIds, (err, data) => {
-        if (err) {
+      return this._api.mpim.open(userIds)
+        .then((data) => {
+          if (!data.ok) {
+            return callback(new Error(data.error));
+          }
+  
+          task.target = data.group.id;
+          return this._sendResponse(task, callback);  
+        })
+        .catch((err) => {
           return callback(err);
-        }
-
-        if (!data.ok) {
-          return callback(new Error(data.error));
-        }
-
-        task.target = data.group.id;
-        this._sendResponse(task, callback);
-      });
+        });
     }
 
     this._sendResponse(task, callback);
@@ -347,13 +345,11 @@ export default class Response extends EventEmitter {
       text,
       channel: id
     })
-    this._api.chat.postMessage(postMessageArguments, (err, res) => {
-      if (err) {
-        return callback(err);
-      }
-
-      callback(null, res);
-    });
+    this._api.chat.postMessage(postMessageArguments)
+      .then((res) => {
+        callback(null, res);
+      })
+      .catch((err) => callback(err));
   }
 
   /**
@@ -371,13 +367,11 @@ export default class Response extends EventEmitter {
       channel: id
     };
 
-    this._api.chat.postMessage(opts, (err, res) => {
-      if (err) {
-        return callback(err);
-      }
-
-      callback(null, res);
-    });
+    this._api.chat.postMessage(opts)
+      .then((res) => {
+        callback(null, res);
+      })
+      .catch((err) => callback(err));
   }
 
   /**

--- a/test/Response.js
+++ b/test/Response.js
@@ -300,7 +300,7 @@ describe('Response', () => {
     const res = new Response(token, dataStoreMock, requestMock, 5);
 
     res._api = apiMock;
-    apiMock.chat.postMessage.callsArgWith(1, null, {});
+    apiMock.chat.postMessage.returns(Promise.resolve({}));
     apiMock.reactions.add.callsArgWith(2, null, {});
 
     res.text('hello');
@@ -326,8 +326,8 @@ describe('Response', () => {
 
     res._api = apiMock;
     dataStoreMock.getUserByName.withArgs('daendels').returns({ id: 'U532122' });
-    apiMock.im.open.callsArgWith(1, null, dmOpenApiMock);
-    apiMock.chat.postMessage.callsArgWith(1, null, {});
+    apiMock.im.open.returns(Promise.resolve(dmOpenApiMock));
+    apiMock.chat.postMessage.returns(Promise.resolve({}));
 
     res.text('try dm', '@daendels').send().then(() => {
       const fixedTask = {
@@ -358,8 +358,8 @@ describe('Response', () => {
     res._api = apiMock;
     dataStoreMock.getUserByName.withArgs('daendels').returns({ id: 'U532122' });
     dataStoreMock.getDMById.withArgs('D123124').returns({ user: 'U124523' });
-    apiMock.mpim.open.callsArgWith(1, null, mpimOpenApiMock);
-    apiMock.chat.postMessage.callsArgWith(1, null, {});
+    apiMock.mpim.open.returns(Promise.resolve(mpimOpenApiMock));
+    apiMock.chat.postMessage.returns(Promise.resolve({}));
 
     res.text('try mpim', [
       '@daendels',
@@ -392,7 +392,7 @@ describe('Response', () => {
 
     res._api = apiMock;
     dataStoreMock.getUserByName.withArgs('daendels').returns({ id: 'U532122' });
-    apiMock.im.open.callsArgWith(1, dmOpenApiMock);
+    apiMock.im.open.returns(Promise.reject(dmOpenApiMock));
 
     res.on('task_error', err => {
       err.should.be.equal(dmOpenApiMock);
@@ -412,7 +412,7 @@ describe('Response', () => {
 
     res._api = apiMock;
     dataStoreMock.getUserByName.withArgs('daendels').returns({ id: 'U532122' });
-    apiMock.im.open.callsArgWith(1, null, dmOpenApiMock);
+    apiMock.im.open.returns(Promise.resolve(dmOpenApiMock));
 
     res.on('task_error', err => {
       err.message.should.be.equal(errorMessage);
@@ -428,7 +428,7 @@ describe('Response', () => {
 
     res._api = apiMock;
     dataStoreMock.getUserByName.withArgs('daendels').returns({ id: 'U532122' });
-    apiMock.mpim.open.callsArgWith(1, dmOpenApiMock);
+    apiMock.mpim.open.returns(Promise.reject(dmOpenApiMock));
 
     res.on('task_error', err => {
       err.should.be.equal(dmOpenApiMock);
@@ -448,7 +448,7 @@ describe('Response', () => {
 
     res._api = apiMock;
     dataStoreMock.getUserByName.withArgs('daendels').returns({ id: 'U532122' });
-    apiMock.mpim.open.callsArgWith(1, null, dmOpenApiMock);
+    apiMock.mpim.open.returns(Promise.resolve(dmOpenApiMock));
 
     res.on('task_error', err => {
       err.message.should.be.equal(errorMessage);
@@ -463,7 +463,7 @@ describe('Response', () => {
     const errorMock = new Error('failed to post message');
 
     res._api = apiMock;
-    apiMock.chat.postMessage.callsArgWith(1, errorMock);
+    apiMock.chat.postMessage.returns(Promise.reject(errorMock));
 
     res.on('task_error', err => {
       err.should.be.equal(errorMock);
@@ -480,7 +480,7 @@ describe('Response', () => {
     const errorMock = new Error('failed to post attachment');
 
     res._api = apiMock;
-    apiMock.chat.postMessage.callsArgWith(1, errorMock);
+    apiMock.chat.postMessage.returns(Promise.reject(errorMock));
 
     res.on('task_error', err => {
       err.should.be.equal(errorMock);
@@ -610,7 +610,7 @@ describe('Response', () => {
       }, 0);
     })
     .then(() => {
-      apiMock.chat.postMessage.callsArgWith(1, null, {});
+      apiMock.chat.postMessage.returns(Promise.resolve({}));
 
       res._queue.paused.should.be.equal(true);
       res._queue.length().should.be.equal(2);

--- a/test/Robot.js
+++ b/test/Robot.js
@@ -828,7 +828,7 @@ describe('Robot', () => {
 
     robot._dataStore.getUserById.withArgs(messagePayload.user).returns(userMock);
     robot._dataStore.getChannelGroupOrDMById.withArgs(messagePayload.channel).returns(channelMock);
-    postMessageMock.callsArgWith(2, errorMock);
+    postMessageMock.returns(Promise.reject(errorMock));
     listenerStub.returns(listenerMock);
 
     robot.on('response_failed', err => {


### PR DESCRIPTION
Slack is deprecating usage of callbacks in the next version. This will help us migrate to v5