### PR TITLE
fix: handle slack event errors

### DIFF
--- a/lib/Robot.js
+++ b/lib/Robot.js
@@ -401,7 +401,11 @@ var Robot = function (_EventEmitter) {
         var dataStore = _this4._dataStore;
         var rtmClient = _this4._rtm;
         _this4._rtm.on('slack_event', function (type, message) {
-          dataStore.handleRtmMessage(rtmClient.activeUserId, rtmClient.activeTeamId, type, message);
+          try {
+            dataStore.handleRtmMessage(rtmClient.activeUserId, rtmClient.activeTeamId, type, message);
+          } catch (err) {
+            logger.error('Cannot handle RTM message. type: ' + type + ', message: ' + JSON.stringify(message));
+          }
         });
         logger.info('Logged in as ' + _this4.bot.name);
       });

--- a/src/Robot.js
+++ b/src/Robot.js
@@ -303,7 +303,11 @@ export default class Robot extends EventEmitter {
       const dataStore = this._dataStore;
       const rtmClient = this._rtm;
       this._rtm.on('slack_event', (type, message) => {
+        try {
         dataStore.handleRtmMessage(rtmClient.activeUserId, rtmClient.activeTeamId, type, message);
+        } catch(err){
+          logger.error(`Cannot handle RTM message. type: ${type}, message: ${JSON.stringify(message)}`)
+        }
       });
       logger.info(`Logged in as ${this.bot.name}`);
     });


### PR DESCRIPTION

### Description

Handle slack event errors that were causing gynoid to shutdown, in this case everytime anyone _reacts_ to a slack message with an emoji.

Before:
![image](https://user-images.githubusercontent.com/11925502/97233510-d84b3f80-17bd-11eb-9647-42d795f180c1.png)

After: 
![image](https://user-images.githubusercontent.com/11925502/97233532-e00ae400-17bd-11eb-9bd2-2d8d308533d3.png)



### References

https://auth0team.atlassian.net/browse/ESD-9716
